### PR TITLE
Fix splitting in configuration.py

### DIFF
--- a/src/info_provider/configuration.py
+++ b/src/info_provider/configuration.py
@@ -30,7 +30,7 @@ class Configuration:
         try:
             f = open(filepath, 'r')
             for line in f:
-                (key, val) = line.split('=')
+                (key, val) = line.split('=',1)
                 out[key] = self.clear_quotes(self.clear_newlines(val.strip()))
         finally:
             f.close()


### PR DESCRIPTION
I hit a (very corner case!) bug where a configuration variable (in my
case the database password) contained a '=' character, for example:

STORM_DB_PWD='abcdefg=xyz!!!'

which broke the parsing at that line with the error:

'too many values to unpack'

Changing from split('=') to split('=',1) will ensure that the splitting
only happens on the *first* '='.